### PR TITLE
Adds the glmer function from lme4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,3 +8,4 @@
     * `randomForest::randomForest`
     * `lme4::lmer`
     * `quantreg::rq, nlrq, rqss, crq` (thanks to [Joran Elias](https://github.com/joranE))
+    * `lme4::glmer` (thanks to [Mathew Ling](https://github.com/Lingtax/))

--- a/R/glmer.R
+++ b/R/glmer.R
@@ -11,7 +11,7 @@
 #' @export
 #'
 #' @examples
-#' fit <- glmer(cbpp, cbind(incidence, size - incidence) ~ period + (1 | herd), family = binomial)
+#' fit <- glmer(lme4::cbpp, cbind(incidence, size - incidence) ~ period + (1 | herd), family = binomial)
 #' summary(fit)
 #'
 #' # Help page for function being twiddled

--- a/R/glmer.R
+++ b/R/glmer.R
@@ -1,0 +1,33 @@
+#' data.frame-first formula-second method for \code{\link[lme4]{glmer}}
+#'
+#' This function passes a data.frame, formula, and additional arguments to
+#' \code{\link[lme4]{glmer}}
+#'
+#' @seealso \code{\link[lme4]{glmer}}
+#'
+#' @param data frame containing the variables in the model
+#' @inheritParams lme4::lmer
+#' @param ... Additional arguments to pass to model function
+#' @export
+#'
+#' @examples
+#' fit <- glmer(cbpp, cbind(incidence, size - incidence) ~ period + (1 | herd), family = binomial)
+#' summary(fit)
+#'
+#' # Help page for function being twiddled
+#' ?lme4::glmer
+#'
+glmer <- function(data, formula, ...) {
+  check_pkg("lme4")
+  UseMethod("glmer")
+}
+
+#' @export
+glmer.default <- function(data, formula, ...) {
+  glmer.data.frame(as.data.frame(data), formula, ...)
+}
+
+#' @export
+glmer.data.frame <- function(data, formula, ...) {
+  lme4::glmer(formula = formula, data = data, ...)
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -60,6 +60,7 @@ x <- data.frame(rbind(
   c("rpart", "rpart"),
   c("randomForest", "randomForest"),
   c("lme4", "lmer"),
+  c("lme4", "glmer"),
   c("quantreg","rq"),
   c("quantreg","nlrq"),
   c("quantreg","rqss"),

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ data.frame-first formula-second model functions exposed by twidlr:
 | Package      | Function     |
 |:-------------|:-------------|
 | glmnet       | glmnet       |
+| lme4         | glmer        |
 | lme4         | lmer         |
 | quantreg     | crq          |
 | quantreg     | nlrq         |

--- a/tests/testthat/test-glmer.R
+++ b/tests/testthat/test-glmer.R
@@ -1,6 +1,6 @@
 context("glmer")
 
 test_that("== lme4 output", {
-  expect_equal(stats::coef(twidlr::glmer(cbpp, cbind(incidence, size - incidence) ~ period + (1 | herd), family = binomial)),
-               stats::coef(lme4::glmer(cbind(incidence, size - incidence) ~ period + (1 | herd),cbpp, family = binomial)))
+  expect_equal(stats::coef(twidlr::glmer(lme4::cbpp, cbind(incidence, size - incidence) ~ period + (1 | herd), family = binomial)),
+               stats::coef(lme4::glmer(cbind(incidence, size - incidence) ~ period + (1 | herd), lme4::cbpp, family = binomial)))
 })

--- a/tests/testthat/test-glmer.R
+++ b/tests/testthat/test-glmer.R
@@ -1,0 +1,6 @@
+context("glmer")
+
+test_that("== lme4 output", {
+  expect_equal(stats::coef(twidlr::glmer(cbpp, cbind(incidence, size - incidence) ~ period + (1 | herd), family = binomial)),
+               stats::coef(lme4::glmer(cbind(incidence, size - incidence) ~ period + (1 | herd),cbpp, family = binomial)))
+})


### PR DESCRIPTION
Adapts existing lmer function to allow data-first modelling using lme4::glmer. 
README.Rmd and NEWS.md updated to include this function. Test included. 